### PR TITLE
Include uppercase HTTP/HTTPS proxy variable.

### DIFF
--- a/scripts/welcome.py
+++ b/scripts/welcome.py
@@ -315,6 +315,8 @@ def edit_proxy():
     with open('/tmp/proxy.sh', 'w+') as f:
         f.write('export http_proxy="' + http_proxy + '"\n')
         f.write('export https_proxy="' + https_proxy + '"\n')
+        f.write('export HTTP_PROXY="' + http_proxy + '"\n')
+        f.write('export HTTPS_RPOXY="' + https_proxy + '"\n')
     os.system("sudo mv /tmp/proxy.sh /etc/profile.d/proxy.sh")
     os.system("sudo chown root /etc/profile.d/proxy.sh")
     os.system("sudo chmod 744 /etc/profile.d/proxy.sh")


### PR DESCRIPTION
When behind a proxy server and due to errors trying to upgrade VM version, it is necessary either to include uppercase http/https proxy environment variable or add it (as edited).

This occurs specifically when update script tries to install packages through pip giving the following error as result:

Cannot fetch index base URL https://pypi.python.org/simple/
Could not find any downloads that satisfy the requirement jsonschema==2.6.0 in /usr/local/lib/python3.4/dist-packages (from -r requirements.txt (line 1))
Downloading/unpacking jsonschema==2.6.0 (from -r requirements.txt (line 1))
Cleaning up...
No distributions at all found for jsonschema==2.6.0 in /usr/local/lib/python3.4/dist-packages (from -r requirements.txt (line 1))
Storing debug log for failure in /home/gns3/.pip/pip.log
ERROR DURING UPGRADE PROCESS PLEASE TAKE A SCREENSHOT IF YOU NEED SUPPORT