### PR TITLE
Add tshark installation to GNS3 VM

### DIFF
--- a/config/install.sh
+++ b/config/install.sh
@@ -98,6 +98,9 @@ apt-get install -y dynamips iouyap ubridge
 # Install VNC support for Docker
 apt-get install -y x11vnc xvfb
 
+# Install tshark for packet capture
+apt-get install -y tshark
+
 # Install iou dependencies
 apt-get install -y gns3-iou 
 


### PR DESCRIPTION
## Summary
- Add `tshark` package installation to `config/install.sh`
- Enables packet capture and analysis capabilities in the GNS3 VM environment
- Useful for network troubleshooting and packet inspection during simulations