### PR TITLE
Add XRd (containerized IOS XR) host requirements to the VM

### DIFF
--- a/config/99-gns3-xrd.conf
+++ b/config/99-gns3-xrd.conf
@@ -1,0 +1,14 @@
+# 99-gns3-xrd.conf - System requirements for Cisco XRd (containerized IOS XR)
+# Installed to /etc/sysctl.d/99-gns3-xrd.conf
+#
+# Required by XRd, GNS3 checks these on connection and warns if below:
+fs.inotify.max_user_instances = 64000
+fs.inotify.max_user_watches = 524288
+fs.file-max = 1000000
+
+# Optional, recommended by Cisco xrdocs (XR internal socket buffers,
+# only noticeable with heavy control-plane session scale):
+net.core.rmem_default = 1048576
+net.core.wmem_default = 1048576
+net.core.rmem_max = 134217728
+net.core.wmem_max = 134217728

--- a/config/fuse.conf
+++ b/config/fuse.conf
@@ -1,0 +1,3 @@
+# Load the FUSE kernel module at boot.
+# Required by XRd (/dev/fuse is passed into the container).
+fuse

--- a/config/install.sh
+++ b/config/install.sh
@@ -197,3 +197,16 @@ chown root:root /etc/network/if-up.d/gns3-ifup
 cp 50-qlen_gns3.conf /etc/sysctl.d/50-qlen_gns3.conf
 chmod 755 /etc/sysctl.d/50-qlen_gns3.conf
 chown root:root /etc/network/if-up.d/gns3-ifup
+
+# System requirements for XRd (containerized IOS XR)
+cp 99-gns3-xrd.conf /etc/sysctl.d/99-gns3-xrd.conf
+chmod 644 /etc/sysctl.d/99-gns3-xrd.conf
+chown root:root /etc/sysctl.d/99-gns3-xrd.conf
+sysctl -p /etc/sysctl.d/99-gns3-xrd.conf || true
+
+# Load the FUSE kernel module at boot (required by XRd, /dev/fuse)
+mkdir -p /etc/modules-load.d
+cp fuse.conf /etc/modules-load.d/fuse.conf
+chmod 644 /etc/modules-load.d/fuse.conf
+chown root:root /etc/modules-load.d/fuse.conf
+modprobe fuse || true


### PR DESCRIPTION
## Summary

Bake the host-level system requirements for Cisco XRd (containerized IOS XR) into the GNS3 VM, as discussed in GNS3/gns3-server#2678 (VM-side portion).

## Changes

- **`config/99-gns3-xrd.conf`** (new) → installed to `/etc/sysctl.d/99-gns3-xrd.conf`:
  - `fs.inotify.max_user_instances = 64000` (XRd uses ~4000 per node; default 128 breaks it)
  - `fs.inotify.max_user_watches = 524288`
  - `fs.file-max = 1000000`
  - socket buffer sizes recommended by Cisco xrdocs (`net.core.rmem_default/wmem_default = 1048576`, `net.core.rmem_max/wmem_max = 134217728`)
- **`config/fuse.conf`** (new) → installed to `/etc/modules-load.d/fuse.conf`, loads the FUSE kernel module at boot (XRd uses FUSE filesystems internally, needs `/dev/fuse`)
- **`config/install.sh`**: install both files and apply them immediately (`sysctl -p`, `modprobe fuse`), so no reboot is needed after an upgrade

## Testing

These settings were verified on my openSUSE Tumbleweed host. I have **not** tested them on other distributions (including the Ubuntu-based GNS3 VM image) — feedback from other environments is welcome.

## References

- GNS3/gns3-server#2678
- Cisco XRd host environment setup: https://xrdocs.io/virtual-routing/tutorials/2022-08-22-setting-up-host-environment-to-run-xrd
- xrd-tools host-check: https://github.com/ios-xr/xrd-tools/blob/main/scripts/host-check