### PR TITLE
tune sysctl params for xrd

### DIFF
--- a/config/99-gns3-xrd.conf
+++ b/config/99-gns3-xrd.conf
@@ -3,12 +3,15 @@
 #
 # Required by XRd, GNS3 checks these on connection and warns if below:
 fs.inotify.max_user_instances = 64000
-fs.inotify.max_user_watches = 524288
-fs.file-max = 1000000
+fs.inotify.max_user_watches = 1048576
+fs.file-max = 9223372036854775807
 
 # Optional, recommended by Cisco xrdocs (XR internal socket buffers,
 # only noticeable with heavy control-plane session scale):
-net.core.rmem_default = 1048576
-net.core.wmem_default = 1048576
-net.core.rmem_max = 134217728
-net.core.wmem_max = 134217728
+net.core.rmem_default = 67108864
+net.core.wmem_default = 67108864
+net.core.rmem_max = 67108864
+net.core.wmem_max = 67108864
+net.core.netdev_max_backlog = 300000
+net.core.optmem_max = 67108864
+net.ipv4.udp_mem = "186564 248755 373128"


### PR DESCRIPTION
Tune sysctl parameters based on xrdocs (https://xrdocs.io/virtual-routing/tutorials/xrd-control-plane-on-openshift#tuned) and values set in CML 2.10 which is the latest release to support XRd Control Plane

The settings recommended in the xrdocs and the values found in CML 2.10 are consistent for all parameters except for net.ipv4.udp_mem

xrdocs recommends value of net.ipv4.udp_mem="1124736 10000000 67108864" but CML 2.10 has net.ipv4.udp_mem = "186564 248755 373128". I am going with values provided in CML 2.10, all other parameters are consistent in both xrdocs and CML 2.10

sysadmin@cml-controller:~$ sysctl fs.inotify.max_user_instances fs.inotify.max_user_watches fs.file-max net.core.rmem_max net.core.wmem_max net.core.rmem_default net.core.wmem_default net.core.netdev_max_backlog net.core.optmem_max net.ipv4.udp_mem

fs.inotify.max_user_instances = 64000
fs.inotify.max_user_watches = 1048576
fs.file-max = 9223372036854775807
net.core.rmem_max = 67108864
net.core.wmem_max = 67108864
net.core.rmem_default = 67108864
net.core.wmem_default = 67108864
net.core.netdev_max_backlog = 300000
net.core.optmem_max = 67108864
net.ipv4.udp_mem = 186564       248755  373128